### PR TITLE
fix for multi address type update. When the user entered a record, th…

### DIFF
--- a/rest-api/main.go
+++ b/rest-api/main.go
@@ -65,8 +65,12 @@ func UpdateRecord(domain string, ipaddr string, addrType string) string {
 
     w.WriteString(fmt.Sprintf("server %s\n", appConfig.Server))
     w.WriteString(fmt.Sprintf("zone %s\n", appConfig.Zone))
-    w.WriteString(fmt.Sprintf("update delete %s.%s A\n", domain, appConfig.Domain))
-    w.WriteString(fmt.Sprintf("update delete %s.%s AAAA\n", domain, appConfig.Domain))
+    if addrType == "A" {
+	    w.WriteString(fmt.Sprintf("update delete %s.%s A\n", domain, appConfig.Domain))
+    }
+    if addrType == "AAAA" {
+	    w.WriteString(fmt.Sprintf("update delete %s.%s AAAA\n", domain, appConfig.Domain))
+    }
     w.WriteString(fmt.Sprintf("update add %s.%s %v %s %s\n", domain, appConfig.Domain, appConfig.RecordTTL, addrType, ipaddr))
     w.WriteString("send\n")
 


### PR DESCRIPTION
…e other address type for the same domain was deleted.

For example:

I inserted an A record for domain foo with address 1.1.1.1. 
Then, I inserted an AAAA record for domain foo with address f:f::1.

Expected:
foo.example.org. IN A 1.1.1.1
foo.example.org. IN AAAA f:f::1

Result:
foo.example.org. IN AAAA f:f::1

always both records (A and AAAA) were being deleted. The correct is to delete only the address type which is being updated.

 

