### PR TITLE
Added handlers to support DynDNS compliant requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,45 @@ It provides one single GET request, that is used as follows:
 
 http://myhost.mydomain.tld:8080/update?secret=changeme&domain=foo&addr=1.2.3.4
 
+## DynDNS compatible API
+
+This package contains a DynDNS compatible handler for convenience and for use cases
+where clients cannot be modified to use the JSON responses and/or URL scheme outlined
+above.
+
+This has been tested with a number of routers. Just point the router to your DDNS domain
+for updates.
+
+The handlers will listen on:
+* /nic/update
+* /v2/update
+* /v3/update
+
+
+An example on the ddclient (Linux DDNS client) based Ubiquiti router line:
+
+set service dns dynamic interface eth0 service dyndns host-name <your-ddns-hostname-to-be-updated>
+set service dns dynamic interface eth0 service dyndns login <anything-as-username-is-not-validated>
+set service dns dynamic interface eth0 service dyndns password <shared-secret>
+set service dns dynamic interface eth0 service dyndns protocol dyndns2
+set service dns dynamic interface eth0 service dyndns server <your-ddns-server>
+
+Optional if you used this behind an HTTPS reverse proxy like I do:
+
+set service dns dynamic interface eth0 service dyndns options ssl=true
+
+
+
+This also means that DDCLIENT works out of the box and Linux based devices should work.
+
+D-Link DIR-842:
+
+Another router that has been tested is from the D-Link router line where you need to fill the 
+details in on the Web Interface. The values are self-explanatory. Under the server (once you chosen Manual)
+you need to enter you DDNS server's hostname or IP. The protocol used by the router will be the 
+dyndns2 by default and cannot be changed.
+
+
 ### Fields
 
 * `secret`: The shared secret set in `envfile`
@@ -75,6 +114,14 @@ http://myhost.mydomain.tld:8080/update?secret=changeme&domain=foo&addr=1.2.3.4
    result in `foo.example.org`. Could also be multiple domains that should be
    redirected to the same domain separated by comma, so "foo,bar"
 * `addr`: IPv4 or IPv6 address of the name record
+
+
+For the DynDNS compatible fields please see Dyn's documentation here: 
+
+```
+https://help.dyn.com/remote-access-api/perform-update/
+```
+
 
 ## Accessing the REST API log
 

--- a/rest-api/ipparser_test.go
+++ b/rest-api/ipparser_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
     "testing"
-    "./ipparser"
+    "dyndns/ipparser"
 )
 
 func TestValidIP4ToReturnTrueOnValidAddress(t *testing.T) {

--- a/rest-api/ipparser_test.go
+++ b/rest-api/ipparser_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
     "testing"
-    "dyndns/ipparser"
+    "./ipparser"
 )
 
 func TestValidIP4ToReturnTrueOnValidAddress(t *testing.T) {

--- a/rest-api/main.go
+++ b/rest-api/main.go
@@ -1,119 +1,137 @@
 package main
 
 import (
-    "log"
-    "fmt"
-    "net/http"
-    "io/ioutil"
-    "os"
-    "bufio"
-    "os/exec"
-    "bytes"
-    "encoding/json"
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
 
-    "github.com/gorilla/mux"
+	"github.com/gorilla/mux"
 )
 
 var appConfig = &Config{}
 
 func main() {
-    appConfig.LoadConfig("/etc/dyndns.json")
+	appConfig.LoadConfig("/etc/dyndns.json")
 
-    router := mux.NewRouter().StrictSlash(true)
-    router.HandleFunc("/update", Update).Methods("GET")
-    router.HandleFunc("/nic/update", DynUpdate).Methods("GET")
-    router.HandleFunc("/v2/update", DynUpdate).Methods("GET")
-    router.HandleFunc("/v3/update", DynUpdate).Methods("GET")
+	router := mux.NewRouter().StrictSlash(true)
+	router.HandleFunc("/update", Update).Methods("GET")
 
-    log.Println(fmt.Sprintf("Serving dyndns REST services on 0.0.0.0:8080..."))
-    log.Fatal(http.ListenAndServe(":8080", router))
+	/* DynDNS compatible handlers. Most routers will invoke /nic/update */
+	router.HandleFunc("/nic/update", DynUpdate).Methods("GET")
+	router.HandleFunc("/v2/update", DynUpdate).Methods("GET")
+	router.HandleFunc("/v3/update", DynUpdate).Methods("GET")
+
+	log.Println(fmt.Sprintf("Serving dyndns REST services on 0.0.0.0:8080..."))
+	log.Fatal(http.ListenAndServe(":8080", router))
 }
 
 func DynUpdate(w http.ResponseWriter, r *http.Request) {
-    response := BuildDynResponseFromRequest(r, appConfig)
+    extractor := RequestDataExtractor{
+        Address: func(r *http.Request) string { return r.URL.Query().Get("myip") },
+        Secret:  func(r *http.Request) string {     _, sharedSecret, ok := r.BasicAuth()
+            if !ok || sharedSecret == "" {
+                sharedSecret = r.URL.Query().Get("password")
+            }
 
-    if response.Success == false {
-        if response.Message == "Domain not set" {
-            w.Write([]byte("notfqdn\n"))
-        } else {
-            w.Write([]byte("badauth\n"))
-        }
-        return
+            return sharedSecret
+        },
+        Domain:  func(r *http.Request) string { return r.URL.Query().Get("hostname") },
     }
+	response := BuildWebserviceResponseFromRequest(r, appConfig, extractor)
 
-    for _, domain := range response.Domains {
-        result := UpdateRecord(domain, response.Address, response.AddrType)
+	if response.Success == false {
+		if response.Message == "Domain not set" {
+			w.Write([]byte("notfqdn\n"))
+		} else {
+			w.Write([]byte("badauth\n"))
+		}
+		return
+	}
 
-        if result != "" {
-            response.Success = false
-            response.Message = result
+	for _, domain := range response.Domains {
+		result := UpdateRecord(domain, response.Address, response.AddrType)
 
-            w.Write([]byte("dnserr\n"))
-            return
-        }
-    }
+		if result != "" {
+			response.Success = false
+			response.Message = result
 
-    response.Success = true
-    response.Message = fmt.Sprintf("Updated %s record for %s to IP address %s", response.AddrType, response.Domain, response.Address)
+			w.Write([]byte("dnserr\n"))
+			return
+		}
+	}
 
-    w.Write([]byte(fmt.Sprintf("good %s\n", response.Address)))
+	response.Success = true
+	response.Message = fmt.Sprintf("Updated %s record for %s to IP address %s", response.AddrType, response.Domain, response.Address)
+
+	w.Write([]byte(fmt.Sprintf("good %s\n", response.Address)))
 }
 
 func Update(w http.ResponseWriter, r *http.Request) {
-    response := BuildWebserviceResponseFromRequest(r, appConfig)
+	extractor := RequestDataExtractor{
+		Address: func(r *http.Request) string { return r.URL.Query().Get("addr") },
+		Secret:  func(r *http.Request) string { return r.URL.Query().Get("secret") },
+		Domain:  func(r *http.Request) string { return r.URL.Query().Get("domain") },
+	}
+	response := BuildWebserviceResponseFromRequest(r, appConfig, extractor)
 
-    if response.Success == false {
-        json.NewEncoder(w).Encode(response)
-        return
-    }
+	if response.Success == false {
+		json.NewEncoder(w).Encode(response)
+		return
+	}
 
-    for _, domain := range response.Domains {
-        result := UpdateRecord(domain, response.Address, response.AddrType)
+	for _, domain := range response.Domains {
+		result := UpdateRecord(domain, response.Address, response.AddrType)
 
-        if result != "" {
-            response.Success = false
-            response.Message = result
+		if result != "" {
+			response.Success = false
+			response.Message = result
 
-            json.NewEncoder(w).Encode(response)
-            return
-        }
-    }
+			json.NewEncoder(w).Encode(response)
+			return
+		}
+	}
 
-    response.Success = true
-    response.Message = fmt.Sprintf("Updated %s record for %s to IP address %s", response.AddrType, response.Domain, response.Address)
+	response.Success = true
+	response.Message = fmt.Sprintf("Updated %s record for %s to IP address %s", response.AddrType, response.Domain, response.Address)
 
-    json.NewEncoder(w).Encode(response)
+	json.NewEncoder(w).Encode(response)
 }
 
 func UpdateRecord(domain string, ipaddr string, addrType string) string {
-    log.Println(fmt.Sprintf("%s record update request: %s -> %s", addrType, domain, ipaddr))
+	log.Println(fmt.Sprintf("%s record update request: %s -> %s", addrType, domain, ipaddr))
 
-    f, err := ioutil.TempFile(os.TempDir(), "dyndns")
-    if err != nil {
-        return err.Error()
-    }
+	f, err := ioutil.TempFile(os.TempDir(), "dyndns")
+	if err != nil {
+		return err.Error()
+	}
 
-    defer os.Remove(f.Name())
-    w := bufio.NewWriter(f)
+	defer os.Remove(f.Name())
+	w := bufio.NewWriter(f)
 
-    w.WriteString(fmt.Sprintf("server %s\n", appConfig.Server))
-    w.WriteString(fmt.Sprintf("zone %s\n", appConfig.Zone))
-    w.WriteString(fmt.Sprintf("update delete %s.%s %s\n", domain, appConfig.Domain, addrType))
-    w.WriteString(fmt.Sprintf("update add %s.%s %v %s %s\n", domain, appConfig.Domain, appConfig.RecordTTL, addrType, ipaddr))
-    w.WriteString("send\n")
+	w.WriteString(fmt.Sprintf("server %s\n", appConfig.Server))
+	w.WriteString(fmt.Sprintf("zone %s\n", appConfig.Zone))
+	w.WriteString(fmt.Sprintf("update delete %s.%s %s\n", domain, appConfig.Domain, addrType))
+	w.WriteString(fmt.Sprintf("update add %s.%s %v %s %s\n", domain, appConfig.Domain, appConfig.RecordTTL, addrType, ipaddr))
+	w.WriteString("send\n")
 
-    w.Flush()
-    f.Close()
+	w.Flush()
+	f.Close()
 
-    cmd := exec.Command(appConfig.NsupdateBinary, f.Name())
-    var out bytes.Buffer
-    var stderr bytes.Buffer
-    cmd.Stdout = &out
-    cmd.Stderr = &stderr
-    err = cmd.Run()
-    if err != nil {
-        return err.Error() + ": " + stderr.String()
-    }
+	cmd := exec.Command(appConfig.NsupdateBinary, f.Name())
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	if err != nil {
+		return err.Error() + ": " + stderr.String()
+	}
 
-    return out.String()
+	return out.String()
 }

--- a/rest-api/request_handler.go
+++ b/rest-api/request_handler.go
@@ -81,3 +81,70 @@ func BuildWebserviceResponseFromRequest(r *http.Request, appConfig *Config) Webs
 
     return response
 }
+
+func BuildDynResponseFromRequest(r *http.Request, appConfig *Config) WebserviceResponse {
+    response := WebserviceResponse{}
+
+    var sharedSecret string
+
+    vals := r.URL.Query()
+    _, sharedSecret, ok := r.BasicAuth()
+    if !ok || sharedSecret == "" {
+        sharedSecret = vals.Get("password")
+    }
+
+    response.Domains = strings.Split(vals.Get("hostname"), ",")
+    response.Address = vals.Get("myip")
+
+    if sharedSecret != appConfig.SharedSecret {
+        log.Println(fmt.Sprintf("Invalid shared secret: %s", sharedSecret))
+        response.Success = false
+        response.Message = "Invalid Credentials"
+        return response
+    }
+
+    for _, domain := range response.Domains {
+        if domain == "" {
+            response.Success = false
+            response.Message = fmt.Sprintf("Domain not set")
+            log.Println("Domain not set")
+            return response
+        }
+    }
+
+    // kept in the response for compatibility reasons
+    response.Domain = strings.Join(response.Domains, ",")
+
+    if ipparser.ValidIP4(response.Address) {
+        response.AddrType = "A"
+    } else if ipparser.ValidIP6(response.Address) {
+        response.AddrType = "AAAA"
+    } else {
+        ip, _, err := net.SplitHostPort(r.RemoteAddr)
+
+        if err != nil {
+            response.Success = false
+            response.Message = fmt.Sprintf("%q is neither a valid IPv4 nor IPv6 address", r.RemoteAddr)
+            log.Println(fmt.Sprintf("Invalid address: %q", r.RemoteAddr))
+            return response
+        }
+
+        // @todo refactor this code to remove duplication
+        if ipparser.ValidIP4(ip) {
+            response.AddrType = "A"
+            response.Address = ip
+        } else if ipparser.ValidIP6(ip) {
+            response.AddrType = "AAAA"
+            response.Address = ip
+        } else {
+            response.Success = false
+            response.Message = fmt.Sprintf("%s is neither a valid IPv4 nor IPv6 address", response.Address)
+            log.Println(fmt.Sprintf("Invalid address: %s", response.Address))
+            return response
+        }
+    }
+
+    response.Success = true
+
+    return response
+}

--- a/rest-api/request_handler.go
+++ b/rest-api/request_handler.go
@@ -7,7 +7,7 @@ import (
     "net/http"
     "strings"
 
-    "./ipparser"
+    "dyndns/ipparser"
 )
 
 type RequestDataExtractor struct {

--- a/rest-api/request_handler.go
+++ b/rest-api/request_handler.go
@@ -1,14 +1,20 @@
 package main
 
 import (
-    "log"
     "fmt"
+    "log"
     "net"
     "net/http"
     "strings"
 
-    "dyndns/ipparser"
+    "./ipparser"
 )
+
+type RequestDataExtractor struct {
+    Address func (request *http.Request) string
+    Secret func (request *http.Request) string
+    Domain func (request *http.Request) string
+}
 
 type WebserviceResponse struct {
     Success bool
@@ -19,15 +25,12 @@ type WebserviceResponse struct {
     AddrType string
 }
 
-func BuildWebserviceResponseFromRequest(r *http.Request, appConfig *Config) WebserviceResponse {
+func BuildWebserviceResponseFromRequest(r *http.Request, appConfig *Config, extractors RequestDataExtractor) WebserviceResponse {
     response := WebserviceResponse{}
 
-    var sharedSecret string
-
-    vals := r.URL.Query()
-    sharedSecret = vals.Get("secret")
-    response.Domains = strings.Split(vals.Get("domain"), ",")
-    response.Address = vals.Get("addr")
+    sharedSecret := extractors.Secret(r)
+    response.Domains = strings.Split(extractors.Domain(r), ",")
+    response.Address = extractors.Address(r)
 
     if sharedSecret != appConfig.SharedSecret {
         log.Println(fmt.Sprintf("Invalid shared secret: %s", sharedSecret))
@@ -62,73 +65,6 @@ func BuildWebserviceResponseFromRequest(r *http.Request, appConfig *Config) Webs
             return response
         }
         
-        // @todo refactor this code to remove duplication
-        if ipparser.ValidIP4(ip) {
-            response.AddrType = "A"
-            response.Address = ip
-        } else if ipparser.ValidIP6(ip) {
-            response.AddrType = "AAAA"
-            response.Address = ip
-        } else {
-            response.Success = false
-            response.Message = fmt.Sprintf("%s is neither a valid IPv4 nor IPv6 address", response.Address)
-            log.Println(fmt.Sprintf("Invalid address: %s", response.Address))
-            return response
-        }
-    }
-
-    response.Success = true
-
-    return response
-}
-
-func BuildDynResponseFromRequest(r *http.Request, appConfig *Config) WebserviceResponse {
-    response := WebserviceResponse{}
-
-    var sharedSecret string
-
-    vals := r.URL.Query()
-    _, sharedSecret, ok := r.BasicAuth()
-    if !ok || sharedSecret == "" {
-        sharedSecret = vals.Get("password")
-    }
-
-    response.Domains = strings.Split(vals.Get("hostname"), ",")
-    response.Address = vals.Get("myip")
-
-    if sharedSecret != appConfig.SharedSecret {
-        log.Println(fmt.Sprintf("Invalid shared secret: %s", sharedSecret))
-        response.Success = false
-        response.Message = "Invalid Credentials"
-        return response
-    }
-
-    for _, domain := range response.Domains {
-        if domain == "" {
-            response.Success = false
-            response.Message = fmt.Sprintf("Domain not set")
-            log.Println("Domain not set")
-            return response
-        }
-    }
-
-    // kept in the response for compatibility reasons
-    response.Domain = strings.Join(response.Domains, ",")
-
-    if ipparser.ValidIP4(response.Address) {
-        response.AddrType = "A"
-    } else if ipparser.ValidIP6(response.Address) {
-        response.AddrType = "AAAA"
-    } else {
-        ip, _, err := net.SplitHostPort(r.RemoteAddr)
-
-        if err != nil {
-            response.Success = false
-            response.Message = fmt.Sprintf("%q is neither a valid IPv4 nor IPv6 address", r.RemoteAddr)
-            log.Println(fmt.Sprintf("Invalid address: %q", r.RemoteAddr))
-            return response
-        }
-
         // @todo refactor this code to remove duplication
         if ipparser.ValidIP4(ip) {
             response.AddrType = "A"


### PR DESCRIPTION
With this patch the docker-ddns container is able to respond to standard DynDNS compliant requests (eg. coming from routers with clients which cannot change the URL pattern used for update).

I tested this with a few routers:

- Ubiquiti ER-4: The server URL is changeable but not the URL pattern, therefor there was no way to pass in secret and the other vars.
- D-Link DIR-842: Again, I could change the URL but not what's sent.

This inspired this change so I can use these clients against this project.