### PR TITLE
DNS update with FQDN in domain field, main.go

### DIFF
--- a/rest-api/main.go
+++ b/rest-api/main.go
@@ -42,7 +42,12 @@ func DynUpdate(w http.ResponseWriter, r *http.Request) {
 
 			return sharedSecret
 		},
-		Domain: func(r *http.Request) string { return r.URL.Query().Get("hostname") },
+		Domain: func(r *http.Request) string {
+			confDomain := "." + appConfig.Domain
+			srcDomain := r.URL.Query().Get("hostname")
+			srcDomain = strings.Replace(srcDomain, confDomain, "", -1)
+			return srcDomain
+		},
 	}
 	response := BuildWebserviceResponseFromRequest(r, appConfig, extractor)
 
@@ -77,7 +82,12 @@ func Update(w http.ResponseWriter, r *http.Request) {
 	extractor := RequestDataExtractor{
 		Address: func(r *http.Request) string { return r.URL.Query().Get("addr") },
 		Secret:  func(r *http.Request) string { return r.URL.Query().Get("secret") },
-		Domain:  func(r *http.Request) string { return r.URL.Query().Get("domain") },
+		Domain: func(r *http.Request) string {
+			confDomain := "." + appConfig.Domain
+			srcDomain := r.URL.Query().Get("domain")
+			srcDomain = strings.Replace(srcDomain, confDomain, "", -1)
+			return srcDomain
+		},
 	}
 	response := BuildWebserviceResponseFromRequest(r, appConfig, extractor)
 


### PR DESCRIPTION
This pull requests removes the  "ZONE" string from the "hostname" or "domain" fields of the request, as this is used by AVM fritz!box routers to check if the update is actually executed, but would recursively lead to updates in the form of:

ZONE=example.com
request url:
https://ddns.example.com/v3/update?hostname=hostname.example.com&myip=<ipaddr>&password=<passwd>
Resulting entry in the zone file: hostname.example.com.example.com

Solves #63