### PR TITLE
enable transfer and NS server definition

### DIFF
--- a/envfile
+++ b/envfile
@@ -1,3 +1,5 @@
 SHARED_SECRET=changeme
 ZONE=example.org
 RECORD_TTL=3600
+NS=ns1.example.org,ns2.example.org
+TRANSFERIP=192.168.100.5;192.168.100.6


### PR DESCRIPTION
I add two parameters: NS and transfer.
Since most DNS client can't recognize the NS server as localhost, so I added NS which support multiple server separated with a comma.

Also, I added TRANSFERIP to support multiple slave dns server. 