### PR TITLE
Nginx reverse proxy configuration

### DIFF
--- a/extra/nginx.conf
+++ b/extra/nginx.conf
@@ -1,0 +1,22 @@
+# this configuration is a SSL reverse proxy to the DDNS REST API
+# bonus: it will automatically append the IP of the remote client to the query string passed to the API
+
+server {
+        listen 8081 ssl;
+        listen [::]:8081 ssl;
+        server_name ns.domain.ltd; # update accordingly
+
+        include snippets/self-signed.conf; # you will have to configure SSL certificates
+
+        access_log /var/log/nginx/dyndns-access.log;
+        error_log /var/log/nginx/dyndns-error.log;
+
+        location / {
+      		set $delimeter "";
+      		if ($is_args) {
+      			set $delimeter "&";
+      		}
+      		set $args "$args${delimeter}addr=$remote_addr";
+      		proxy_pass http://127.0.0.1:8080$uri$is_args$args;
+	}
+}


### PR DESCRIPTION
You can use this NGINX site configuration to create a reverse HTTPS proxy to the DDNS REST API endpoint. As a bonus it will automatically append the client remote IP address to the query string passed to the API.