### PR TITLE
Bump base image version to debian:trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster as builder
+FROM debian:trixie as builder
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
 	apt-get install -q -y golang git-core && \
 	apt-get clean
@@ -6,9 +6,16 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
 ENV GOPATH=/root/go
 RUN mkdir -p /root/go/src
 COPY rest-api /root/go/src/dyndns
-RUN cd /root/go/src/dyndns && go get && go test -v
 
-FROM debian:buster-slim
+WORKDIR /root/go/src/dyndns
+
+RUN go mod init dyndns && \
+    go get -d -v && \
+    go test -v
+
+RUN go build -o /root/go/bin/dyndns .
+
+FROM debian:trixie-slim
 MAINTAINER David Prandzioch <hello+ddns@davd.eu>
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
@@ -22,4 +29,4 @@ COPY named.conf.options /etc/bind/named.conf.options
 COPY --from=builder /root/go/bin/dyndns /root/dyndns
 
 EXPOSE 53 8080
-CMD ["sh", "-c", "/root/setup.sh ; service bind9 start ; /root/dyndns"]
+CMD ["sh", "-c", "/root/setup.sh ; service named start ; /root/dyndns"]


### PR DESCRIPTION
Bumps base image version to debian:trixie, fixes build step and starts named service.